### PR TITLE
Add the shipping status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Create an issue if you need help, or need more services than the ones provided.
 | Barcode webservice                            |      ✓      |   1_1   |
 | Confirming webservice                         |      ✓      |   1_10  |
 | Labelling webservice                          |      ✓      |   2_1   |
-| Shippingstatus webservice                     |      X      |   N/A   |
+| Shippingstatus webservice                     |      ✓      |   v2   |
 | **Delivery options**                                                |||
 | Deliverydate webservice                       |      X      |   N/A   |
 | Location webservice                           |      ✓      |   2_1   |
@@ -205,6 +205,14 @@ if (!empty($result['GetLocationsResult']['ResponseLocation'])) {
     $result = $api->getLabellingService()->generateLabel($shipments, $message);
     print_r($result);
 }
+```
+
+
+### Code example: Get the shipping status (via a barcode)
+```
+$endpoints = new Sandbox();
+$api = new API($key, new Customer(), $endpoints);
+$data = $api->getShippingStatusService()->getByBarcode($barcode);
 ```
 
 ---

--- a/Soneritics/PostNL/API.php
+++ b/Soneritics/PostNL/API.php
@@ -31,6 +31,7 @@ use PostNL\Service\ConfirmService;
 use PostNL\Service\LabellingService;
 use PostNL\Service\LocationsService;
 use PostNL\Service\PostalcodeService;
+use PostNL\Service\ShippingStatusService;
 use PostNL\Service\TimeframeService;
 
 /**
@@ -131,4 +132,9 @@ class API
     {
         return new PostalcodeService($this->apiKey, $this->customer, $this->endpoints->PostalCode);
     }
+
+    public function getShippingStatusService(): ShippingStatusService
+	{
+		return new ShippingStatusService($this->apiKey, $this->customer, $this->endpoints->ShippingStatus);
+	}
 }

--- a/Soneritics/PostNL/Endpoints/Production.php
+++ b/Soneritics/PostNL/Endpoints/Production.php
@@ -38,4 +38,5 @@ class Production extends Endpoints
     public $Timeframe = 'https://api.postnl.nl/shipment/v2_1';
     public $Locations = 'https://api.postnl.nl/shipment/v2_1/locations';
     public $PostalCode = 'https://api.postnl.nl/shipment/checkout/v1';
+    public $ShippingStatus = 'https://api.postnl.nl/shipment/v2/status';
 }

--- a/Soneritics/PostNL/Endpoints/Sandbox.php
+++ b/Soneritics/PostNL/Endpoints/Sandbox.php
@@ -38,4 +38,5 @@ class Sandbox extends Endpoints
     public $Timeframe = 'https://api-sandbox.postnl.nl/shipment/v2_1';
     public $Locations = 'https://api-sandbox.postnl.nl/shipment/v2_1/locations';
     public $PostalCode = 'https://api-sandbox.postnl.nl/shipment/checkout/v1';
+    public $ShippingStatus = 'https://api-sandbox.postnl.nl/shipment/v2/status';
 }

--- a/Soneritics/PostNL/Service/ConfirmService.php
+++ b/Soneritics/PostNL/Service/ConfirmService.php
@@ -45,7 +45,7 @@ class ConfirmService extends AbstractService
      */
     public function confirmShipment(Shipments $shipments, Message $message)
     {
-        $serviceResult = $this->post(
+        return $this->post(
             '/confirm',
             [
                 'Customer' => $this->customer,
@@ -53,8 +53,5 @@ class ConfirmService extends AbstractService
                 'Shipments' => $shipments
             ]
         );
-
-        // Directly return the serviceResult - @todo
-        return $serviceResult;
     }
 }

--- a/Soneritics/PostNL/Service/LabellingService.php
+++ b/Soneritics/PostNL/Service/LabellingService.php
@@ -46,7 +46,7 @@ class LabellingService extends AbstractService
      */
     public function generateLabel(Shipments $shipments, Message $message, bool $confirm = true)
     {
-        $serviceResult = $this->post(
+        return $this->post(
             '/label?confirm=' . ($confirm ? 'true' : 'false'),
             [
                 'Customer' => $this->customer,
@@ -54,8 +54,5 @@ class LabellingService extends AbstractService
                 'Shipments' => $shipments
             ]
         );
-
-        // Directly return the serviceResult - @todo
-        return $serviceResult;
     }
 }

--- a/Soneritics/PostNL/Service/ShippingStatusService.php
+++ b/Soneritics/PostNL/Service/ShippingStatusService.php
@@ -22,65 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace PostNL\Endpoints;
+
+namespace PostNL\Service;
 
 /**
- * Endpoints
- *
- * @author Jordi Jolink <mail@jordijolink.nl>
- * @since  27-5-2018
+ * Shipping Status Service.
  */
-abstract class Endpoints
+class ShippingStatusService extends AbstractService
 {
     /**
+     * Get the status by a barcode.
      *
-     * @var string
-     */
-    public $Barcode;
-
-    /**
-     *
-     * @var string
-     */
-    public $Confirm;
-
-    /**
-     *
-     * @var string
-     */
-    public $Labelling;
-
-    /**
-     *
-     * @var string
-     */
-    public $Timeframe;
-
-    /**
-     *
-     * @var string
-     */
-    public $Locations;
-
-    /**
-     *
-     * @var string
-     */
-    public $PostalCode;
-
-	/**
-	 * @var string
-	 */
-    public $ShippingStatus;
-
-    /**
-     * Endpoints constructor.
-     * Check if all endpoints are implemented.
+     * @param string $barcode
+     * @param string $detail
+     * @param string $language
      *
      * @throws \Exception
+     *
+     * @return string
      */
-    public function __construct()
+    public function getByBarcode(string $barcode, string $detail = 'true', string $language = 'NL')
     {
-        // @todo: Loop all class properties and check if !empty()
+        return $this->get("/barcode/{$barcode}", [
+            'detail'   => $detail,
+            'language' => $language,
+        ]);
     }
 }


### PR DESCRIPTION
This adds the shipping status API: https://developer.postnl.nl/browse-apis/send-and-track/shippingstatus-webservice/documentation/

For now, the shipping status is only requestable by `barcode`. 

**Notes:** 
- You can ask more information with `detail=true` or `detail=false`, but it needs to be a string :/  That is why $detail is not a `boolean`:
```php
public function getByBarcode(string $barcode, string $detail = 'true', string $language = 'NL')
```

- Could you update the version if you decide to merge it?