### PR TITLE
Add ERS (Easy Return Service) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Create an issue if you need help, or need more services than the ones provided.
 | **Send & Track**                                                    |||
 | Barcode webservice                            |      ✓      |   1_1   |
 | Confirming webservice                         |      ✓      |   1_10  |
-| Labelling webservice                          |      ✓      |   2_1   |
+| Labelling webservice                          |      ✓      |   2_2*   |
 | Shippingstatus webservice                     |      ✓      |   v2   |
 | **Delivery options**                                                |||
 | Deliverydate webservice                       |      X      |   N/A   |
@@ -41,6 +41,8 @@ Create an issue if you need help, or need more services than the ones provided.
 | Timeframe webservice                          |      ✓      |   2_1   |
 | **Checkout**                                                |||
 | Postalcode Check                              |      ✓      |   1   |
+
+> *`v2_2` supports ERS labels
 
 ### Code example: Creating the API
 Always start with creating the API object.
@@ -255,4 +257,18 @@ $voormelding->addPakket($pakket);
 // Contents ophalen. Dit kan opgeslagen worden in een LST bestand.
 $voormeldContents = $voormelding->genereerInhoud()
 ```
+
+---
+## ERS
+
+### Using ERS
+
+The product code for ERS labels is `4910`.
+
+PostNL does not have documentation available for this product code, but you can use the documentation from product code `3085 Return label in the box` as a base.
+There are additional things required for using ERS:
+- The `CustomerCode` (4 letters) should have ERS enabled, or be ERS specific. Contact PostNL support for this.
+- The `Addressses` of the `Customer` and `Shipment` all need to have a `name` filled in.
+- The `ReturnBarcode` should be set.
+
 

--- a/Soneritics/PostNL/Endpoints/Production.php
+++ b/Soneritics/PostNL/Endpoints/Production.php
@@ -34,7 +34,7 @@ class Production extends Endpoints
 {
     public $Barcode = 'https://api.postnl.nl/shipment/v1_1';
     public $Confirm = 'https://api.postnl.nl/shipment/v1_10';
-    public $Labelling = 'https://api.postnl.nl/shipment/v2_1';
+    public $Labelling = 'https://api.postnl.nl/shipment/v2_2';
     public $Timeframe = 'https://api.postnl.nl/shipment/v2_1';
     public $Locations = 'https://api.postnl.nl/shipment/v2_1/locations';
     public $PostalCode = 'https://api.postnl.nl/shipment/checkout/v1';

--- a/Soneritics/PostNL/Endpoints/Sandbox.php
+++ b/Soneritics/PostNL/Endpoints/Sandbox.php
@@ -22,19 +22,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 namespace PostNL\Endpoints;
 
 /**
- * Sandbox endpoints
+ * Sandbox endpoints.
  *
  * @author Jordi Jolink <mail@jordijolink.nl>
+ *
  * @since  27-5-2018
  */
 class Sandbox extends Endpoints
 {
     public $Barcode = 'https://api-sandbox.postnl.nl/shipment/v1_1';
     public $Confirm = 'https://api-sandbox.postnl.nl/shipment/v1_10';
-    public $Labelling = 'https://api-sandbox.postnl.nl/shipment/v2_1';
+    public $Labelling = 'https://api-sandbox.postnl.nl/shipment/v2_2';
     public $Timeframe = 'https://api-sandbox.postnl.nl/shipment/v2_1';
     public $Locations = 'https://api-sandbox.postnl.nl/shipment/v2_1/locations';
     public $PostalCode = 'https://api-sandbox.postnl.nl/shipment/checkout/v1';


### PR DESCRIPTION
The labelling webservice `v2_2` supports ERS (Easy Return Service) labels, whilst the `v2_1` does not. 

The url below seems to suggest that moving to `v2_2` contains breaking changes. For the project I use it, generating all the other (non-ERS) still worked fine. So it might be good to version this as `3.0`.

https://developer.postnl.nl/browse-apis/send-and-track/labelling-webservice/documentation/
![afbeelding](https://user-images.githubusercontent.com/36499489/88522197-4f720b80-cff6-11ea-998a-88f9ee41eacc.png)
 