### PR TITLE
Expose the service http client so you can set auth and proxy settings

### DIFF
--- a/Soneritics/PostNL/Service/AbstractService.php
+++ b/Soneritics/PostNL/Service/AbstractService.php
@@ -45,6 +45,12 @@ abstract class AbstractService
 
     /**
      *
+     * @var \PestJSON
+     */
+    private $httpClient;
+    
+    /**
+     *
      * @var Customer
      */
     protected $customer;
@@ -64,6 +70,29 @@ abstract class AbstractService
     }
 
     /**
+     * Get http client instance
+     * 
+     * @return \PestJSON
+     */
+    public function getHttpClient()
+    {
+        if(!$this->httpClient) {
+            $this->httpClient = new \PestJSON($this->endpoint);
+        }
+        return $this->httpClient;
+    }
+
+    /**
+     * Set http client instance
+     * 
+     * @param \PestJSON $client
+     */
+    public function setHttpClient(\PestJSON $client)
+    {
+        $this->httpClient = $client;
+    }
+    
+    /**
      * Get data from a REST call.
      *
      * @param  $url
@@ -73,7 +102,7 @@ abstract class AbstractService
      */
     protected function get($url, $data)
     {
-        return (new \PestJSON($this->endpoint))->get($url, $data, $this->getHeaders());
+        return $this->getHttpClient()->get($url, $data, $this->getHeaders());
     }
 
     /**
@@ -86,7 +115,7 @@ abstract class AbstractService
      */
     protected function post($url, $data)
     {
-        return (new \PestJSON($this->endpoint))->post($url, $data, $this->getHeaders());
+        return $this->getHttpClient()->post($url, $data, $this->getHeaders());
     }
 
     /**


### PR DESCRIPTION
In order to make connection over http proxy you can now do the following (example barcode service):

$service = $api->getBarcodeService();
$client = $service->getHttpClient();
$client->setupProxy($host, $port, $user, $pass);
$service->setHttpClient($client);
$barcode = $service->generateBarcode();
