### PR TITLE
add product options to shipment, this is mandatory for some products

### DIFF
--- a/Soneritics/PostNL/Model/ProductOption.php
+++ b/Soneritics/PostNL/Model/ProductOption.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2020 Soneritics.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace PostNL\Model;
+
+use PostNL\Business\AutoJsonSerializer;
+
+/**
+ * Shipment
+ */
+class ProductOption extends AutoJsonSerializer
+{
+    /**
+     * Mandatory
+     * 
+     * @var string
+     */
+    protected $Characteristic = "118";
+    
+    /**
+     * Mandatory
+     * 
+     * @var string
+     */
+    protected $Option = "006";
+    
+    /**
+     *
+     * @return string
+     */
+    public function getCharacteristic(): string
+    {
+        return $this->Characteristic;
+    }
+    
+    /**
+     *
+     * @param  string $Characteristic
+     * @return ProductOption
+     */
+    public function setCharacteristic(string $Characteristic): ProductOption
+    {
+        $this->Characteristic = $Characteristic;
+        return $this;
+    }
+    
+    /**
+     *
+     * @return string
+     */
+    public function getOption(): string
+    {
+        return $this->Option;
+    }
+    
+    /**
+     *
+     * @param  string $Option
+     * @return ProductOption
+     */
+    public function setOption(string $Option): ProductOption
+    {
+        $this->Option = $Option;
+        return $this;
+    }
+}

--- a/Soneritics/PostNL/Model/Shipment.php
+++ b/Soneritics/PostNL/Model/Shipment.php
@@ -213,6 +213,12 @@ class Shipment extends AutoJsonSerializer
 
     /**
      *
+     * @var array
+     */
+    protected $ProductOptions = [];
+    
+    /**
+     *
      * @return Addresses
      */
     public function getAddresses(): Addresses
@@ -787,5 +793,26 @@ class Shipment extends AutoJsonSerializer
     {
         $this->TimeslotID = $TimeslotID;
         return $this;
+    }
+
+    /**
+     * Add a product option
+     *
+     * @param  ProductOption $productOption
+     * @return Shipment
+     */
+    public function addProductOption(ProductOption $productOption) : Shipment
+    {
+        $this->ProductOptions[] = $productOption;
+        return $this;
+    }
+    
+    /**
+     *
+     * @return array
+     */
+    public function getProductOptions()
+    {
+        return $this->ProductOptions;
     }
 }


### PR DESCRIPTION
Hi,

I added functionality for shipment "ProductOptions".
This is needed for some postNL products, see for example "smart returns".

Cheers and thanks for this library, I use it in production for one of my clients for few months now.

Al